### PR TITLE
Support 2FA Ring.com authentication with OTP codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,18 @@ Currently (doorbells), lights, floodlights, sirens
 
 ## limitations
 Tested only with camera and floodlight devices.  Alarms not currently supported.
-2FA not supported
+
+## Ring Account 2FA Authentication
+The ring adapter now supports two-factor authentication using one-time passcodes and refresh tokens.
+To configure the ring device adapter:
+
+1. Enter your email and password associated with your Ring account on the ring-adapter add-ons configuration page.
+2. Initially leave the OTP (One-time passcode) field empty and click **Apply**. 
+3. You will then be prompted to provide the otp that was sent to your email or mobile (This may take a few seconds).
+4. Enter the OTP (Within 10 minutes) and click **Apply** again.
+5. Your Ring devices will then be discoverable on the Things page (Click the **+** and **Save** button).
+
+**Note:** *Should your refresh token become invalid or expire just re-enter your password and repeat the otp verification steps (2-4) above to be issued a new refresh token.*
 
 ## credits
 Thanks to dgreif for maintaining a robust implementation of the ring api

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = (addonManager, manifest, errorCallback) => {
     return;
   }
 
-  if (!config.RingCredentials.password) {
-    errorCallback(manifest.name, 'Ring Account Password is Required!');
+  if (!config.RingCredentials.password && !config.refreshToken) {
+    errorCallback(manifest.name, 'Ring Account Password / Refresh Token is Required!');
     return;
   }
 

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -3,9 +3,10 @@
  */
 'use strict';
 
-const {Adapter} = require('gateway-addon');
+const {Adapter, Database} = require('gateway-addon');
 const RingDevice = require('./ring-device');
 const {RingApi} = require('ring-client-api');
+const {RingRestClient} = require('ring-client-api/lib/api/rest-client');
 
 /**
  * Adapter for Ring devices.
@@ -26,19 +27,40 @@ class RingAdapter extends Adapter {
     this.pairing = false;
     this.activityResetIntervalMS = 18000; // reset the activity after 18 secs
 
-    this.ringApi = new RingApi({
-      // without 2fa
-      email: this.config.RingCredentials.email,
-      password: this.config.RingCredentials.password,
-      
-      // with 2fa or if you dont want to store your email/password in your config
-      refreshToken: 'token generated with ring-auth-cli.  See https://github.com/dgreif/ring/wiki/Two-Factor-Auth',
-    
-      // The following are all optional. See below for details
-      cameraStatusPollingSeconds: 10,
-      cameraDingsPollingSeconds: this.config.pollInterval,
-    });
+    Promise.resolve(this.config.refreshToken)
+     .then((refreshToken) => {
+        // Obtain a refresh token if we don't have one or otp or password has been provided.
+        if (!refreshToken || this.config.RingCredentials.password || this.config.RingCredentials.otp) {
+          return this.acquireRefreshToken();
+        }
+        return refreshToken;
+      })
+     .then((refreshToken) => {
 
+        if (!refreshToken) {
+          console.error("Unable to connect to Ring api. No refresh token.");
+          return;
+        }
+
+        this.ringApi = new RingApi({
+          // with 2fa or if you dont want to store your email/password in your config
+          refreshToken: refreshToken,
+        
+          // The following are all optional. See below for details
+          cameraStatusPollingSeconds: 10,
+          cameraDingsPollingSeconds: this.config.pollInterval
+        });
+        this.ringApi.onRefreshTokenUpdated.subscribe(
+          async ({ oldRefreshToken, newRefreshToken }) => {
+            this.ringApi.refreshToken = newRefreshToken;
+            this.onRefreshTokenUpdated(newRefreshToken);
+          }
+        );
+        this.discoverDevices();
+      });
+  }
+
+  discoverDevices() {
     console.log(`Fetching Ring devices for account ${this.config.RingCredentials.email}`);
 
     this.ringApi.getCameras().then((cameras) => {
@@ -241,18 +263,76 @@ class RingAdapter extends Adapter {
                 'id', this.id, 'pairing started');
     this.pairingEnd = Date.now() + _timeoutSeconds * 1000;
     this.pairing = true;
-    this.pair();
+    
   }
 
   /**
-   * Internal Adapter Pair processing.
-   *
-   * @param {Number} timeoutSeconds Number of seconds to run before timeout
+   * Verifies Ring credentials and generates refresh token (If otp provided).
    */
-  pair() {
-    console.log(this.name,
-                'id', this.id, 'pairing routine started');
-    let polling = false;
+  async acquireRefreshToken() {
+    const ringRestClient = new RingRestClient({ 
+      email: this.config.RingCredentials.email, 
+      password: this.config.RingCredentials.password 
+    });
+
+    const getAuthWith2fa = async () => {
+      try {
+        console.log('Attempting authentication with 2fa otp');
+        return await ringRestClient.getAuth(this.config.RingCredentials.otp)
+      } catch (_) {
+        throw new Error('Incorrect 2fa code. Please configure and try again.')
+      }
+    }
+    const auth = await ringRestClient.getCurrentAuth().catch((e) => {
+      if (ringRestClient.using2fa) {
+        if (!this.config.RingCredentials.otp) {
+          if (this.sendPairingPrompt) {
+            this.sendPairingPrompt(
+              // eslint-disable-next-line max-len
+              'Ring Authentication: Please enter the One-Time-Passcode sent to your email/mobile',
+              '/settings/addons/config/ring-adapter'
+            );
+          }
+          throw new Error('Ring 2fa or verification code is enabled.  Please enter code from the text/email.')
+        } else {
+          return getAuthWith2fa()
+        }
+      }
+      console.error(e)
+    })
+
+    // Save the refresh token
+    this.onRefreshTokenUpdated(auth.refresh_token);
+ 
+    return auth.refresh_token;
+  }
+
+  /**
+   * Handles update of refresh token
+   * @param {} newRefreshToken 
+   */
+  async onRefreshTokenUpdated(newRefreshToken) {
+    console.log(`Refresh Token updated and saved`);
+    
+    const config = this.config;
+    config.refreshToken = newRefreshToken;
+    
+    // clear password and otp as we have a refresh token
+    config.RingCredentials.password = ''; 
+    config.RingCredentials.otp = '';
+
+    this.saveConfig(config);
+  };
+
+  /**
+   * Updates and persists config
+   * @param {} config 
+   */
+  async saveConfig(config) {
+    console.log(`Saving config`);
+    const db = new Database(this.packageName);
+    await db.open();
+    await db.saveConfig(config);
   }
 
   /**

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,7 @@
     "default": {
       "email": "", 
       "password": "", 
+      "otp": "", 
       "pollInterval": 10
     }, 
     "schema": {
@@ -29,6 +30,10 @@
               "type": "string"
             }, 
             "password": {
+              "type": "string"
+            }, 
+            "otp": {
+              "description": "Enter the OTP sent via text/email",
               "type": "string"
             }
           }, 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/damooooooooooh/ring-adapter/issues"
   },
   "dependencies": {
-    "ring-client-api": "^5.12.0"
+    "ring-client-api": "^9.6.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
@@ -55,7 +55,8 @@
     "config": {
       "RingCredentials": {
         "email": "",
-        "password": ""
+        "password": "",
+        "otp": ""
       },
       "pollInterval": 10
     },
@@ -70,8 +71,7 @@
           "type": "object",
           "description": "Enter your ring.com credentials",
           "required": [
-            "email",
-            "password"
+            "email"
           ],
           "properties": {
             "email": {
@@ -79,13 +79,17 @@
             },
             "password": {
               "type": "string"
+            },
+            "otp": {
+              "description": "Enter the OTP sent via text/email",
+              "type": "string"
             }
           }
         },
         "pollInterval": {
-          "description": "Interval in seconds to poll the Ring api. Default 10.",
+          "description": "Interval in seconds blah to poll the Ring api. Default 10.",
           "type": "number",
-          "minimum": 8,
+          "minimum": 5,
           "maximum": 60
         }
       }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
           }
         },
         "pollInterval": {
-          "description": "Interval in seconds blah to poll the Ring api. Default 10.",
+          "description": "Interval in seconds to poll the Ring api. Default 10.",
           "type": "number",
           "minimum": 5,
           "maximum": 60


### PR DESCRIPTION
Since Jan/Feb 2020 2FA authentication is mandatory to use Ring.com APIs.

A workaround up till now was to provide a refresh token using details provided [here](https://github.com/dgreif/ring/wiki/Refresh-Tokens#refresh-token-expiration)

This PR adds the ability to provide OTP codes directly using the ring-adapter add-on configuration page.

Instructions are in the Readme.md