### PR TITLE
Add live video stream support to ring-adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-to-manifest.py
 *.sha256sum
 *.tgz
 .DS_Store
+build/

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = (addonManager, manifest, errorCallback) => {
   }
 
   if (!config.pollInterval) {
-    errorCallback(manifest.name, 'Specify a poll Interval between ' + config.pollInterval.minimum + ' and ' + config.pollInterval.maximum);
+    errorCallback(manifest.name, `Specify a poll Interval between ${config.pollInterval.minimum} and ${config.pollInterval.maximum}`);
     return;
   }
 

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -75,7 +75,7 @@ class RingAdapter extends Adapter {
           const sirenActive = (camera.hasSiren) ? ((camera.data.siren_status.seconds_remaining === 0) ? false : true) : false;
           const hasLight = camera.hasLight;
           const lightOn = (camera.hasLight) ? ((camera.data.led_status === 'on') ? true : false) : false;
-          
+
           this.addDevice(deviceId, deviceName, model, kind,
                          hasLowbattery, batteryLevel, hasSiren, sirenActive,
                          hasLight, lightOn, camera);

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -76,10 +76,10 @@ class RingAdapter extends Adapter {
           const sirenActive = (camera.hasSiren) ? ((camera.data.siren_status.seconds_remaining === 0) ? false : true) : false;
           const hasLight = camera.hasLight;
           const lightOn = (camera.hasLight) ? ((camera.data.led_status === 'on') ? true : false) : false;
-
+          
           this.addDevice(deviceId, deviceName, model, kind,
                          hasLowbattery, batteryLevel, hasSiren, sirenActive,
-                         hasLight, lightOn);
+                         hasLight, lightOn, camera);
 
           console.log(`Found Ring device: ${deviceName} with model type ${model}. deviceId: ${deviceId}`);
           //console.log(model, kind, hasLowbattery, batteryLevel, hasSiren, sirenActive, hasLight, lightOn);
@@ -196,11 +196,12 @@ class RingAdapter extends Adapter {
    * @param {boolean} sirenActive Boolean Indicating if the siren is active,
    * @param {boolean} hasLight Boolean Indicating if the Device has a light,
    * @param {boolean} lightOn Boolean indicating if the light is on/off,
+   * @param {RingCamera} camera The camera device as returned by ring-client-api,
    * @return {Promise} which resolves to the device added.
    */
   addDevice(deviceId, deviceName, model,
             deviceKind, hasLowBattery, batteryLevel,
-            hasSiren, sirenActive, hasLight, lightOn){
+            hasSiren, sirenActive, hasLight, lightOn, camera){
     return new Promise((resolve, reject) => {
       let device = this.devices[deviceId];
 
@@ -211,7 +212,7 @@ class RingAdapter extends Adapter {
         device = new RingDevice(this, deviceId,
                                 deviceName, model, deviceKind,
                                 hasLowBattery, batteryLevel,
-                                hasSiren, sirenActive, hasLight, lightOn);
+                                hasSiren, sirenActive, hasLight, lightOn, camera);
         this.handleDeviceAdded(device);
         resolve(device);
       }

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -98,6 +98,12 @@ class RingAdapter extends Adapter {
                   if (motionProp.value !== motion) {
                     motionProp.setCachedValue(motion);
                     device.notifyPropertyChanged(motionProp);
+
+                    // Record on motion
+                    if (this.config.RecordingOptions.recordOnMotion) {
+                      device.startRecording(this.config.RecordingOptions.recordDuration)
+                      device.clearOldRecordings(this.config.RecordingOptions.clearOldRecordingsAfter)
+                    }
                   }
                 }
               }
@@ -109,6 +115,12 @@ class RingAdapter extends Adapter {
                   if (dingProp.value !== ding) {
                     dingProp.setCachedValue(ding);
                     device.notifyPropertyChanged(dingProp);
+
+                    // Record on ding
+                    if (this.config.RecordingOptions.recordOnDing) {
+                      device.startRecording(this.config.RecordingOptions.recordDuration)
+                      device.clearOldRecordings(this.config.RecordingOptions.clearOldRecordingsAfter)
+                    }
                   }
                 }
               }

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -28,30 +28,29 @@ class RingAdapter extends Adapter {
     this.activityResetIntervalMS = 18000; // reset the activity after 18 secs
 
     Promise.resolve(this.config.refreshToken)
-     .then((refreshToken) => {
+      .then((refreshToken) => {
         // Obtain a refresh token if we don't have one or otp or password has been provided.
         if (!refreshToken || this.config.RingCredentials.password || this.config.RingCredentials.otp) {
           return this.acquireRefreshToken();
         }
         return refreshToken;
       })
-     .then((refreshToken) => {
-
+      .then((refreshToken) => {
         if (!refreshToken) {
-          console.error("Unable to connect to Ring api. No refresh token.");
+          console.error('Unable to connect to Ring api. No refresh token.');
           return;
         }
 
         this.ringApi = new RingApi({
           // with 2fa or if you dont want to store your email/password in your config
           refreshToken: refreshToken,
-        
+
           // The following are all optional. See below for details
           cameraStatusPollingSeconds: 10,
-          cameraDingsPollingSeconds: this.config.pollInterval
+          cameraDingsPollingSeconds: this.config.pollInterval,
         });
         this.ringApi.onRefreshTokenUpdated.subscribe(
-          async ({ oldRefreshToken, newRefreshToken }) => {
+          async ({_, newRefreshToken}) => {
             this.ringApi.refreshToken = newRefreshToken;
             this.onRefreshTokenUpdated(newRefreshToken);
           }
@@ -76,13 +75,13 @@ class RingAdapter extends Adapter {
           const sirenActive = (camera.hasSiren) ? ((camera.data.siren_status.seconds_remaining === 0) ? false : true) : false;
           const hasLight = camera.hasLight;
           const lightOn = (camera.hasLight) ? ((camera.data.led_status === 'on') ? true : false) : false;
-          
+
           this.addDevice(deviceId, deviceName, model, kind,
                          hasLowbattery, batteryLevel, hasSiren, sirenActive,
                          hasLight, lightOn, camera);
 
           console.log(`Found Ring device: ${deviceName} with model type ${model}. deviceId: ${deviceId}`);
-          //console.log(model, kind, hasLowbattery, batteryLevel, hasSiren, sirenActive, hasLight, lightOn);
+          // console.log(model, kind, hasLowbattery, batteryLevel, hasSiren, sirenActive, hasLight, lightOn);
 
           // Handle Ring device Notifications (dings)
           camera.onNewDing.subscribe((ding) => {
@@ -113,7 +112,7 @@ class RingAdapter extends Adapter {
                   }
                 }
               }
- 
+
               setTimeout(() => {
                 console.log(`reset ding: ${ding.id} of kind ${ding.kind} for device ${deviceId}`);
                 if (ding.kind === 'motion') {
@@ -174,7 +173,7 @@ class RingAdapter extends Adapter {
                   device.notifyPropertyChanged(batteryProp);
                 }
               }
-            }            
+            }
           });
         });
       }
@@ -192,7 +191,7 @@ class RingAdapter extends Adapter {
    * @param {String} deviceKind The Ring Device Kind,
    * @param {boolean} hasLowBattery Boolean indicating a low battery,
    * @param {Number} batteryLevel The battery Level percentage,
-   * @param {boolean} hasSiren Boolean Indicating if the device has a Siren, 
+   * @param {boolean} hasSiren Boolean Indicating if the device has a Siren,
    * @param {boolean} sirenActive Boolean Indicating if the siren is active,
    * @param {boolean} hasLight Boolean Indicating if the Device has a light,
    * @param {boolean} lightOn Boolean indicating if the light is on/off,
@@ -201,8 +200,8 @@ class RingAdapter extends Adapter {
    */
   addDevice(deviceId, deviceName, model,
             deviceKind, hasLowBattery, batteryLevel,
-            hasSiren, sirenActive, hasLight, lightOn, camera){
-    return new Promise((resolve, reject) => {
+            hasSiren, sirenActive, hasLight, lightOn, camera) {
+    return new Promise((resolve) => {
       let device = this.devices[deviceId];
 
       if (device) {
@@ -264,26 +263,25 @@ class RingAdapter extends Adapter {
                 'id', this.id, 'pairing started');
     this.pairingEnd = Date.now() + _timeoutSeconds * 1000;
     this.pairing = true;
-    
   }
 
   /**
    * Verifies Ring credentials and generates refresh token (If otp provided).
    */
   async acquireRefreshToken() {
-    const ringRestClient = new RingRestClient({ 
-      email: this.config.RingCredentials.email, 
-      password: this.config.RingCredentials.password 
+    const ringRestClient = new RingRestClient({
+      email: this.config.RingCredentials.email,
+      password: this.config.RingCredentials.password
     });
 
     const getAuthWith2fa = async () => {
       try {
         console.log('Attempting authentication with 2fa otp');
-        return await ringRestClient.getAuth(this.config.RingCredentials.otp)
+        return await ringRestClient.getAuth(this.config.RingCredentials.otp);
       } catch (_) {
-        throw new Error('Incorrect 2fa code. Please configure and try again.')
+        throw new Error('Incorrect 2fa code. Please configure and try again.');
       }
-    }
+    };
     const auth = await ringRestClient.getCurrentAuth().catch((e) => {
       if (ringRestClient.using2fa) {
         if (!this.config.RingCredentials.otp) {
@@ -294,40 +292,40 @@ class RingAdapter extends Adapter {
               '/settings/addons/config/ring-adapter'
             );
           }
-          throw new Error('Ring 2fa or verification code is enabled.  Please enter code from the text/email.')
+          throw new Error('Ring 2fa or verification code is enabled.  Please enter code from the text/email.');
         } else {
-          return getAuthWith2fa()
+          return getAuthWith2fa();
         }
       }
-      console.error(e)
-    })
+      console.error(e);
+    });
 
     // Save the refresh token
     this.onRefreshTokenUpdated(auth.refresh_token);
- 
+
     return auth.refresh_token;
   }
 
   /**
    * Handles update of refresh token
-   * @param {} newRefreshToken 
+   * @param {} newRefreshToken
    */
   async onRefreshTokenUpdated(newRefreshToken) {
     console.log(`Refresh Token updated and saved`);
-    
+
     const config = this.config;
     config.refreshToken = newRefreshToken;
-    
+
     // clear password and otp as we have a refresh token
-    config.RingCredentials.password = ''; 
+    config.RingCredentials.password = '';
     config.RingCredentials.otp = '';
 
     this.saveConfig(config);
-  };
+  }
 
   /**
    * Updates and persists config
-   * @param {} config 
+   * @param {} config
    */
   async saveConfig(config) {
     console.log(`Saving config`);
@@ -375,14 +373,13 @@ class RingAdapter extends Adapter {
 
   setSiren(deviceId, value) {
     return new Promise((resolve, reject) => {
-      const device = this.devices[deviceId];
       const ringDeviceId = deviceId.split('-')[2];
       // Get a reference to the api Camera Object
       // This API has no camera collection to reference
       // so we need to flatten the cameras from the locations
       this.ringApi.getLocations().then((locations) => {
         if (locations) {
-          const camera = locations.reduce((cameras, location) => [...cameras, ...location.cameras], []).filter(camera => camera.id == ringDeviceId)[0];
+          const camera = locations.reduce((cameras, location) => [...cameras, ...location.cameras], []).filter((camera) => camera.id == ringDeviceId)[0];
           if (camera) {
             return camera;
           } else {
@@ -391,7 +388,7 @@ class RingAdapter extends Adapter {
         }
       }).then((camera) => {
         if (camera) {
-          if(camera.hasSiren) {
+          if (camera.hasSiren) {
             camera.setSiren(value);
             resolve();
           }
@@ -402,14 +399,13 @@ class RingAdapter extends Adapter {
 
   setLight(deviceId, value) {
     return new Promise((resolve, reject) => {
-      const device = this.devices[deviceId];
       const ringDeviceId = deviceId.split('-')[2];
       // Get a reference to the api Camera Object
       // This API has no camera collection to reference
       // so we need to flatten the cameras from the locations
       this.ringApi.getLocations().then((locations) => {
         if (locations) {
-          const camera = locations.reduce((cameras, location) => [...cameras, ...location.cameras], []).filter(camera => camera.id == ringDeviceId)[0];
+          const camera = locations.reduce((cameras, location) => [...cameras, ...location.cameras], []).filter((camera) => camera.id == ringDeviceId)[0];
           if (camera) {
             return camera;
           } else {
@@ -418,7 +414,7 @@ class RingAdapter extends Adapter {
         }
       }).then((camera) => {
         if (camera) {
-          if(camera.hasLight) {
+          if (camera.hasLight) {
             camera.setLight(value);
             resolve();
           }

--- a/lib/ring-adapter.js
+++ b/lib/ring-adapter.js
@@ -75,7 +75,7 @@ class RingAdapter extends Adapter {
           const sirenActive = (camera.hasSiren) ? ((camera.data.siren_status.seconds_remaining === 0) ? false : true) : false;
           const hasLight = camera.hasLight;
           const lightOn = (camera.hasLight) ? ((camera.data.led_status === 'on') ? true : false) : false;
-
+          
           this.addDevice(deviceId, deviceName, model, kind,
                          hasLowbattery, batteryLevel, hasSiren, sirenActive,
                          hasLight, lightOn, camera);

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -16,10 +16,10 @@ function getMediaPath(mediaDir) {
   }
 
   let profileDir;
-  if (process.env.hasOwnProperty('MOZIOT_HOME')) {
-    profileDir = process.env.MOZIOT_HOME;
+  if (process.env.hasOwnProperty('WEBTHINGS_HOME')) {
+    profileDir = process.env.WEBTHINGS_HOME;
   } else {
-    profileDir = path.join(os.homedir(), '.mozilla-iot');
+    profileDir = path.join(os.homedir(), '.webthings');
   }
 
   return path.join(profileDir, 'media', 'ring-camera');

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -3,11 +3,12 @@
  */
 'use strict';
 
-const { Device, Event } = require('gateway-addon');
+const {Device} = require('gateway-addon');
 const RingProperty = require('./ring-property');
 const path = require('path'),
-fs = require('fs'),
-mkdirp = require('mkdirp');
+  fs = require('fs'),
+  mkdirp = require('mkdirp'),
+  os = require('os');
 
 function getMediaPath(mediaDir) {
   if (mediaDir) {
@@ -38,32 +39,36 @@ class RingDevice extends Device {
    * @param {String} deviceKind The Ring Device Kind,
    * @param {boolean} hasLowBattery Boolean indicating a low battery,
    * @param {Number} batteryLevel The battery Level percentage,
-   * @param {boolean} hasSiren Boolean Indicating if the device has a Siren, 
+   * @param {boolean} hasSiren Boolean Indicating if the device has a Siren,
    * @param {boolean} sirenActive Boolean Indicating if the siren is active,
    * @param {boolean} hasLight Boolean Indicating if the Device has a light,
    * @param {boolean} lightOn Boolean indicating if the light is on/off,
-   * @param {RingCamera} camera The camera device as returned by ring-client-api,
+   * @param {RingCamera} camera The camera device as returned by
+   *   ring-client-api,
    */
 
   constructor(adapter, id, deviceName, model,
               deviceKind, hasLowBattery, batteryLevel,
               hasSiren, sirenActive,
               hasLight, lightOn,
-              camera)
-  {
+              camera) {
     super(adapter, id);
 
     this.deviceId = id;
     this.name = deviceName;
     this.description = model;
     this.camera = camera;
-    this.hasCamera = camera.data.features && camera.data.features.show_vod_settings;
+    this.hasCamera = camera.data.features &&
+      camera.data.features.show_vod_settings;
 
-    this.mediaDir = path.join(getMediaPath(adapter.userProfile.mediaDir), this.deviceId);
+    this.mediaDir = path.join(
+      getMediaPath(adapter.userProfile.mediaDir),
+      this.deviceId
+    );
     if (!fs.existsSync(this.mediaDir)) {
       mkdirp.sync(this.mediaDir, {mode: 0o755});
     }
-    
+
     this['@context'] = 'https://iot.mozilla.org/schemas';
     this['@type'] = ['MotionSensor'];
 
@@ -83,14 +88,14 @@ class RingDevice extends Device {
           },
           false));
 
-          this.addEvent('pressed', {
-            '@type': 'PressedEvent',
-            description: 'Doorbell Pressed',
-          });
-          this.addEvent('released', {
-            '@type': 'ReleasedEvent',
-            description: 'Doorbell released',
-          });
+      this.addEvent('pressed', {
+        '@type': 'PressedEvent',
+        description: 'Doorbell Pressed',
+      });
+      this.addEvent('released', {
+        '@type': 'ReleasedEvent',
+        description: 'Doorbell released',
+      });
     }
 
     if (hasLight) {
@@ -188,45 +193,44 @@ class RingDevice extends Device {
         },
         false));
 
-        if (this.hasCamera) {
-          console.log('Adding Camera')
-          this['@type'].push('VideoCamera', 'Camera');
-          
-          // https://discourse.mozilla.org/t/updating-thing-properties-on-the-gateway-ui-i-e-name-links/41101/7
-    this.properties.set(
-      'video',
-      new RingProperty(
-        this,
-        'video',
-        {
-          '@type': 'VideoProperty',
-          label: 'Live View',
-          type: 'null',
-          readOnly: true,
-          // TODO disable this prop when !streamActive
-          links: [
-            {
-              rel: 'alternate',
-              href: `/media/ring-camera/${this.deviceId}/stream.m3u8`,
-              mediaType: 'application/vnd.apple.mpegurl',
-            },
-          ],
-        },
-        null));
+    if (this.hasCamera) {
+      this['@type'].push('VideoCamera', 'Camera');
 
-        this.properties.set(
+      // https://discourse.mozilla.org/t/updating-thing-properties-on-the-gateway-ui-i-e-name-links/41101/7
+      this.properties.set(
+        'video',
+        new RingProperty(
+          this,
+          'video',
+          {
+            '@type': 'VideoProperty',
+            label: 'Live View',
+            type: 'null',
+            readOnly: true,
+            // TODO disable this prop when !streamActive
+            links: [
+              {
+                rel: 'alternate',
+                href: `/media/ring-camera/${this.deviceId}/stream.m3u8`,
+                mediaType: 'application/vnd.apple.mpegurl',
+              },
+            ],
+          },
+          null));
+
+      this.properties.set(
+        'streamActive',
+        new RingProperty(
+          this,
           'streamActive',
-          new RingProperty(
-            this,
-            'streamActive',
-            {
-              title: 'Streaming',
-              type: 'boolean',
-            },
-            false
-          )
-        );
-      }
+          {
+            title: 'Streaming',
+            type: 'boolean',
+          },
+          false
+        )
+      );
+    }
 
     this.adapter.handleDeviceAdded(this);
   }
@@ -252,16 +256,16 @@ class RingDevice extends Device {
         'delete_segments',
         path.join(this.mediaDir, 'stream.m3u8'),
       ],
-    })
-  
+    });
+
     // Auto Stop after 5 minutes to save battery.
-    setTimeout(this.stopVideoStream, 5 * 60 * 1000) 
+    setTimeout(this.stopVideoStream, 5 * 60 * 1000);
   }
 
   stopVideoStream() {
     if (this.sipSession) {
       console.log(`Stopping video stream for ${this.deviceId}`);
-      sipSession.stop()
+      this.sipSession.stop();
     } else {
       console.warn(`No video stream to stop for ${this.deviceId}`);
     }

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -196,28 +196,6 @@ class RingDevice extends Device {
     if (this.hasCamera) {
       this['@type'].push('VideoCamera', 'Camera');
 
-      // https://discourse.mozilla.org/t/updating-thing-properties-on-the-gateway-ui-i-e-name-links/41101/7
-      this.properties.set(
-        'video',
-        new RingProperty(
-          this,
-          'video',
-          {
-            '@type': 'VideoProperty',
-            label: 'Live View',
-            type: 'null',
-            readOnly: true,
-            // TODO disable this prop when !streamActive
-            links: [
-              {
-                rel: 'alternate',
-                href: `/media/ring-camera/${this.deviceId}/stream.mpd`,
-                mediaType: 'application/dash+xml',
-              },
-            ],
-          },
-          null));
-
       this.properties.set(
         'streamActive',
         new RingProperty(
@@ -253,12 +231,53 @@ class RingDevice extends Device {
         path.join(this.mediaDir, 'stream.mpd'),
       ],
     });
+
+    this.addVideoProperty();
   }
 
-  stopVideoStream() {
+  async addVideoProperty() {
+    // https://discourse.mozilla.org/t/updating-thing-properties-on-the-gateway-ui-i-e-name-links/41101/7
+    this.properties.set(
+      'video',
+      new RingProperty(
+        this,
+        'video',
+        {
+          '@type': 'VideoProperty',
+          label: 'Live View',
+          type: 'null',
+          readOnly: true,
+          // TODO disable this prop when !streamActive
+          links: [
+            {
+              rel: 'alternate',
+              href: `/media/ring-camera/${this.deviceId}/stream.mpd`,
+              mediaType: 'application/dash+xml',
+            },
+          ],
+        },
+        null));
+    
+    // Force the UI To Refresh and add the property to GUI, 
+    // maybe a hack but cannot see any other way to trigger.
+    this.adapter.handleDeviceAdded(this);
+  }
+
+  async removeVideoProperty() {
+    if (this.properties.has('video')) {
+      this.properties.delete('video');
+      // Force the UI To Refresh and remove the property from GUI, 
+      // It will cause confusion if remains with no content
+      // maybe a hack but cannot see any other way to trigger.
+      this.adapter.handleDeviceAdded(this);
+    }
+  }  
+
+  async stopVideoStream() {
     if (this.sipSession) {
       console.log(`Stopping video stream for ${this.deviceId}`);
-      this.sipSession.stop();
+      await this.sipSession.stop();
+      this.removeVideoProperty();
     } else {
       console.warn(`No video stream to stop for ${this.deviceId}`);
     }

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -5,7 +5,24 @@
 
 const { Device, Event } = require('gateway-addon');
 const RingProperty = require('./ring-property');
+const path = require('path'),
+fs = require('fs'),
+mkdirp = require('mkdirp');
 
+function getMediaPath(mediaDir) {
+  if (mediaDir) {
+    return path.join(mediaDir, 'ring-camera');
+  }
+
+  let profileDir;
+  if (process.env.hasOwnProperty('MOZIOT_HOME')) {
+    profileDir = process.env.MOZIOT_HOME;
+  } else {
+    profileDir = path.join(os.homedir(), '.mozilla-iot');
+  }
+
+  return path.join(profileDir, 'media', 'ring-camera');
+}
 
 /**
  * Ring device type.
@@ -25,20 +42,29 @@ class RingDevice extends Device {
    * @param {boolean} sirenActive Boolean Indicating if the siren is active,
    * @param {boolean} hasLight Boolean Indicating if the Device has a light,
    * @param {boolean} lightOn Boolean indicating if the light is on/off,
+   * @param {RingCamera} camera The camera device as returned by ring-client-api,
    */
 
   constructor(adapter, id, deviceName, model,
               deviceKind, hasLowBattery, batteryLevel,
               hasSiren, sirenActive,
-              hasLight, lightOn)
+              hasLight, lightOn,
+              camera)
   {
     super(adapter, id);
 
     this.deviceId = id;
     this.name = deviceName;
     this.description = model;
-    this['@context'] = 'https://iot.mozilla.org/schemas';
+    this.camera = camera;
+    this.hasCamera = camera.data.features && camera.data.features.show_vod_settings;
 
+    this.mediaDir = path.join(getMediaPath(adapter.userProfile.mediaDir), this.deviceId);
+    if (!fs.existsSync(this.mediaDir)) {
+      mkdirp.sync(this.mediaDir, {mode: 0o755});
+    }
+    
+    this['@context'] = 'https://iot.mozilla.org/schemas';
     this['@type'] = ['MotionSensor'];
 
     // If DeviceKind is of doorbell type, add the button property
@@ -68,7 +94,7 @@ class RingDevice extends Device {
     }
 
     if (hasLight) {
-      this['@type'] = ['MotionSensor', 'Light', 'Alarm'];
+      this['@type'].push('Light');
 
       this.properties.set(
         'light',
@@ -84,6 +110,8 @@ class RingDevice extends Device {
     }
 
     if (hasSiren) {
+      this['@type'].push('Alarm');
+
       this.properties.set(
         'siren',
         new RingProperty(
@@ -160,7 +188,83 @@ class RingDevice extends Device {
         },
         false));
 
+        if (this.hasCamera) {
+          console.log('Adding Camera')
+          this['@type'].push('VideoCamera', 'Camera');
+          
+          // https://discourse.mozilla.org/t/updating-thing-properties-on-the-gateway-ui-i-e-name-links/41101/7
+    this.properties.set(
+      'video',
+      new RingProperty(
+        this,
+        'video',
+        {
+          '@type': 'VideoProperty',
+          label: 'Live View',
+          type: 'null',
+          readOnly: true,
+          // TODO disable this prop when !streamActive
+          links: [
+            {
+              rel: 'alternate',
+              href: `/media/ring-camera/${this.deviceId}/stream.m3u8`,
+              mediaType: 'application/vnd.apple.mpegurl',
+            },
+          ],
+        },
+        null));
+
+        this.properties.set(
+          'streamActive',
+          new RingProperty(
+            this,
+            'streamActive',
+            {
+              title: 'Streaming',
+              type: 'boolean',
+            },
+            false
+          )
+        );
+      }
+
     this.adapter.handleDeviceAdded(this);
+  }
+
+  async startVideoStream() {
+    console.log(`Starting video stream for ${this.deviceId}`);
+
+    this.sipSession = await this.camera.streamVideo({
+      output: [
+        '-preset',
+        'veryfast',
+        '-g',
+        '25',
+        '-sc_threshold',
+        '0',
+        '-f',
+        'hls',
+        '-hls_time',
+        '2',
+        '-hls_list_size',
+        '6',
+        '-hls_flags',
+        'delete_segments',
+        path.join(this.mediaDir, 'stream.m3u8'),
+      ],
+    })
+  
+    // Auto Stop after 5 minutes to save battery.
+    setTimeout(this.stopVideoStream, 5 * 60 * 1000) 
+  }
+
+  stopVideoStream() {
+    if (this.sipSession) {
+      console.log(`Stopping video stream for ${this.deviceId}`);
+      sipSession.stop()
+    } else {
+      console.warn(`No video stream to stop for ${this.deviceId}`);
+    }
   }
 }
 

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -211,8 +211,8 @@ class RingDevice extends Device {
             links: [
               {
                 rel: 'alternate',
-                href: `/media/ring-camera/${this.deviceId}/stream.m3u8`,
-                mediaType: 'application/vnd.apple.mpegurl',
+                href: `/media/ring-camera/${this.deviceId}/stream.mpd`,
+                mediaType: 'application/dash+xml',
               },
             ],
           },
@@ -247,14 +247,10 @@ class RingDevice extends Device {
         '-sc_threshold',
         '0',
         '-f',
-        'hls',
-        '-hls_time',
-        '2',
-        '-hls_list_size',
-        '6',
-        '-hls_flags',
-        'delete_segments',
-        path.join(this.mediaDir, 'stream.m3u8'),
+        'dash',
+        '-remove_at_exit',
+        '1',
+        path.join(this.mediaDir, 'stream.mpd'),
       ],
     });
 

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -58,8 +58,8 @@ class RingDevice extends Device {
     this.name = deviceName;
     this.description = model;
     this.camera = camera;
-    this.hasCamera = camera.data.features &&
-      camera.data.features.show_vod_settings;
+    this.hasCamera = camera.data.settings &&
+      camera.data.settings.enable_vod;
 
     this.mediaDir = path.join(
       getMediaPath(adapter.userProfile.mediaDir),

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -8,7 +8,8 @@ const RingProperty = require('./ring-property');
 const path = require('path'),
   fs = require('fs'),
   mkdirp = require('mkdirp'),
-  os = require('os');
+  os = require('os'),
+  findRemoveSync = require('find-remove');
 
 function getMediaPath(mediaDir) {
   if (mediaDir) {
@@ -65,8 +66,12 @@ class RingDevice extends Device {
       getMediaPath(adapter.userProfile.mediaDir),
       this.deviceId
     );
-    if (!fs.existsSync(this.mediaDir)) {
-      mkdirp.sync(this.mediaDir, {mode: 0o755});
+    this.recordingDir = path.join(
+      this.mediaDir,
+      'recordings'
+    );
+    if (!fs.existsSync(this.recordingDir)) {
+      mkdirp.sync(this.recordingDir, {mode: 0o755});
     }
 
     this['@context'] = 'https://iot.mozilla.org/schemas';
@@ -281,6 +286,22 @@ class RingDevice extends Device {
     } else {
       console.warn(`No video stream to stop for ${this.deviceId}`);
     }
+  }
+
+  async startRecording(recordDuration = 20) {
+    console.log(`Recording video ${this.deviceId}`);
+    const timestamp = new Date().toISOString()
+    await this.camera.recordToFile(path.join(this.recordingDir, `${timestamp}.mp4`), recordDuration)
+  }
+
+  clearOldRecordings(days = 7) {
+    console.log(`Removing recordings older than ${days} days`);
+    findRemoveSync(this.recordingDir, {
+      extensions: ['.mp4'],
+      age: {
+        seconds: days * 86400
+      }
+    });
   }
 }
 

--- a/lib/ring-device.js
+++ b/lib/ring-device.js
@@ -253,9 +253,6 @@ class RingDevice extends Device {
         path.join(this.mediaDir, 'stream.mpd'),
       ],
     });
-
-    // Auto Stop after 5 minutes to save battery.
-    setTimeout(this.stopVideoStream, 5 * 60 * 1000);
   }
 
   stopVideoStream() {

--- a/lib/ring-property.js
+++ b/lib/ring-property.js
@@ -91,7 +91,15 @@ class RingProperty extends Property {
             this.device.notifyPropertyChanged(this);
             this.isUpdating = false;
           });
-      }    
+      } else if (this.name === 'streamActive') {
+        if (value) {
+          this.device.startVideoStream();
+        } else {
+          this.device.stopVideoStream();
+        }
+
+        this.setCachedValueAndNotify(value);
+      }
     });
   }
 }

--- a/lib/ring-property.js
+++ b/lib/ring-property.js
@@ -94,7 +94,6 @@ class RingProperty extends Property {
       } else if (this.name === 'streamActive') {
         if (value) {
           this.device.startVideoStream();
-
           // Auto Stop after 5 minutes to save battery.
           setTimeout(() => {
             this.device.stopVideoStream();

--- a/lib/ring-property.js
+++ b/lib/ring-property.js
@@ -94,6 +94,13 @@ class RingProperty extends Property {
       } else if (this.name === 'streamActive') {
         if (value) {
           this.device.startVideoStream();
+
+          // Auto Stop after 5 minutes to save battery.
+          setTimeout(() => {
+            this.device.stopVideoStream();
+            this.setCachedValueAndNotify(false);
+          }, 5 * 60000);
+
         } else {
           this.device.stopVideoStream();
         }

--- a/lib/ring-property.js
+++ b/lib/ring-property.js
@@ -32,7 +32,7 @@ class RingProperty extends Property {
    * the value passed in.
    */
   setValue(value) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       const backupValue = this.value;
       this.setCachedValue(value);
       resolve(value);
@@ -45,7 +45,7 @@ class RingProperty extends Property {
           .then(() => {
             console.log(`Turned ${textValue} the light for device ${this.device.deviceId}`);
 
-            // As the ring api Synces every 10 secs, lets wait 10 secs 
+            // As the ring api Synces every 10 secs, lets wait 10 secs
             // after updating an block incorrect updates from the api
             setTimeout(() => {
               this.isUpdating = false;
@@ -66,15 +66,15 @@ class RingProperty extends Property {
             console.log(`${textValue} the Alarm for device ${this.device.deviceId}`);
             if (value) {
               this.device.eventNotify(new Event(this.device,
-                                         'alarmEvent',
-                                         'Alarm Triggered!'));
+                                                'alarmEvent',
+                                                'Alarm Triggered!'));
             } else {
               this.device.eventNotify(new Event(this.device,
-                                         'alarmSilenced',
-                                         'Alarm Silenced!'));
+                                                'alarmSilenced',
+                                                'Alarm Silenced!'));
             }
 
-            // As the ring api Synces every 10 secs, lets wait 10 secs 
+            // As the ring api Synces every 10 secs, lets wait 10 secs
             // after updating an block incorrect updates from the api
             setTimeout(() => {
               this.isUpdating = false;
@@ -85,8 +85,8 @@ class RingProperty extends Property {
             const errorMessage = `Could not ${textValue} the Alarm for device ${this.device.deviceId}. ${error}`;
             console.log(errorMessage);
             this.device.eventNotify(new Event(this.device,
-                                       'alarmFailure',
-                                       errorMessage));
+                                              'alarmFailure',
+                                              errorMessage));
             this.setCachedValue(backupValue);
             this.device.notifyPropertyChanged(this);
             this.isUpdating = false;

--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,9 @@
       "email": "", 
       "password": "", 
       "otp": "", 
+      "recordOnDing": false,
+      "recordOnMotion": false,
+      "recordDuration": 20,
       "pollInterval": 10
     }, 
     "schema": {
@@ -35,6 +38,31 @@
             "otp": {
               "description": "Enter the OTP sent via text/email",
               "type": "string"
+            }
+          }, 
+          "type": "object"
+        }, 
+        "RecordingOptions": {
+          "properties": {
+            "recordOnDing": {
+              "description": "Record on ding",
+              "type": "boolean"
+            },
+            "recordOnMotion": {
+              "description": "Record on motion",
+              "type": "boolean"
+            },
+            "recordDuration": {
+              "description": "Number of seconds to record video (20secs = 2.5MB)", 
+              "maximum": 120, 
+              "minimum": 10, 
+              "type": "number"
+            },
+            "clearOldRecordingsAfter": {
+              "description": "Number of days to keep recordings for", 
+              "maximum": 120, 
+              "minimum": 10, 
+              "type": "number"
             }
           }, 
           "type": "object"

--- a/manifest.json
+++ b/manifest.json
@@ -54,5 +54,5 @@
     }
   }, 
   "short_name": "Ring", 
-  "version": "0.0.9"
+  "version": "0.0.10"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ring-adapter",
   "display_name": "Ring",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Ring device adapter for Ring Doorbells, Lights and Sirens.",
   "author": "damooooooooooh",
   "main": "index.js",
@@ -30,6 +30,7 @@
     "url": "https://github.com/damooooooooooh/ring-adapter/issues"
   },
   "dependencies": {
+    "mkdirp": "^1.0.4",
     "ring-client-api": "^9.18.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "url": "https://github.com/damooooooooooh/ring-adapter/issues"
   },
   "dependencies": {
+    "find-remove": "^4.0.4",
     "mkdirp": "^1.0.4",
-    "ring-client-api": "^12.1.0"
+    "ring-client-api": "9.18.6"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
@@ -58,6 +59,12 @@
         "email": "",
         "password": "",
         "otp": ""
+      },
+      "RecordingOptions": {
+        "recordOnDing": false,
+        "recordOnMotion": false,
+        "recordDuration": 20,
+        "clearOldRecordingsAfter": 7
       },
       "pollInterval": 10
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "mkdirp": "^1.0.4",
-    "ring-client-api": "^9.18.6"
+    "ring-client-api": "^12.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.1",

--- a/package.sh
+++ b/package.sh
@@ -1,8 +1,26 @@
 #!/bin/bash
 
 rm -rf node_modules
+rm -rf build
 npm install --production
+rm -f build/SHA256SUMS
+mkdir -p build/{linux,raspbian,darwin,windows}
+
+# Fetch the ffmpeg binaries
+wget -O build/raspbian/ffmpeg-raspbian-armv6l.tar.gz https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/v0.0.9/ffmpeg-raspbian-armv6l.tar.gz
+wget -O build/linux/ffmpeg-debian-x86_64.tar.gz https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/v0.0.9/ffmpeg-debian-x86_64.tar.gz
+wget -O build/darwin/ffmpeg-darwin-x86_64.tar.gz https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/v0.0.9/ffmpeg-darwin-x86_64.tar.gz
+wget -O build/windows/ffmpeg-win32-x86_64.tar.gz https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/v0.0.9/ffmpeg-win32-x86_64.tar.gz
+
+tar -xvf build/raspbian/ffmpeg-raspbian-armv6l.tar.gz -C build/raspbian/ --strip-components 4 ./usr/local/bin/ffmpeg
+tar -xvf build/linux/ffmpeg-debian-x86_64.tar.gz -C build/linux/ --strip-components 4 ./usr/local/bin/ffmpeg
+tar -xvf build/darwin/ffmpeg-darwin-x86_64.tar.gz -C build/darwin/ --strip-components 4 ./usr/local/bin/ffmpeg
+tar -xvf build/windows/ffmpeg-win32-x86_64.tar.gz -C build/windows/
+
+# Build raspbian package
 rm -f SHA256SUMS
+rm node_modules/ffmpeg-for-homebridge/ffmpeg
+cp build/raspbian/ffmpeg node_modules/ffmpeg-for-homebridge/ffmpeg
 sha256sum README.md manifest.json package.json *.js LICENSE > SHA256SUMS
 find lib -type f -exec sha256sum {} \; >> SHA256SUMS
 find node_modules -type f -exec sha256sum {} \; >> SHA256SUMS
@@ -10,7 +28,50 @@ find node_modules -type l -exec sha256sum {} \; >> SHA256SUMS
 TARFILE=$(npm pack)
 tar xzf ${TARFILE}
 cp -r node_modules ./package
-tar czf ${TARFILE} package
+tar czf "${TARFILE/.tgz/-linux-arm.tgz}" package
 rm -rf package
-shasum --algorithm 256 ${TARFILE} > ${TARFILE}.sha256sum
-echo "Created ${TARFILE}"
+shasum --algorithm 256 "${TARFILE/.tgz/-linux-arm.tgz}" > "${TARFILE/.tgz/-linux-arm.tgz}".sha256sum
+rm $TARFILE
+rm "${TARFILE}".sha256sum
+echo "Created ${TARFILE/.tgz/-linux-arm.tgz}"
+
+# Build Linux package
+rm -f SHA256SUMS
+rm node_modules/ffmpeg-for-homebridge/ffmpeg
+cp build/linux/ffmpeg node_modules/ffmpeg-for-homebridge/ffmpeg
+sha256sum README.md manifest.json package.json *.js LICENSE > SHA256SUMS
+find lib -type f -exec sha256sum {} \; >> SHA256SUMS
+find node_modules -type f -exec sha256sum {} \; >> SHA256SUMS
+find node_modules -type l -exec sha256sum {} \; >> SHA256SUMS
+TARFILE=$(npm pack)
+tar xzf ${TARFILE}
+cp -r node_modules ./package
+tar czf "${TARFILE/.tgz/-linux-x64.tgz}" package
+rm -rf package
+shasum --algorithm 256 "${TARFILE/.tgz/-linux-x64.tgz}" > "${TARFILE/.tgz/-linux-x64.tgz}".sha256sum
+rm $TARFILE
+rm "${TARFILE}".sha256sum
+echo "Created ${TARFILE/.tgz/-linux-x64.tgz}"
+
+# Build darwin package
+rm -f SHA256SUMS
+rm node_modules/ffmpeg-for-homebridge/ffmpeg
+cp build/darwin/ffmpeg node_modules/ffmpeg-for-homebridge/ffmpeg
+sha256sum README.md manifest.json package.json *.js LICENSE > SHA256SUMS
+find lib -type f -exec sha256sum {} \; >> SHA256SUMS
+find node_modules -type f -exec sha256sum {} \; >> SHA256SUMS
+find node_modules -type l -exec sha256sum {} \; >> SHA256SUMS
+TARFILE=$(npm pack)
+tar xzf ${TARFILE}
+cp -r node_modules ./package
+tar czf "${TARFILE/.tgz/-darwin-x64.tgz}" package
+rm -rf package
+shasum --algorithm 256 "${TARFILE/.tgz/-darwin-x64.tgz}" > "${TARFILE/.tgz/-darwin-x64.tgz}".sha256sum
+rm $TARFILE
+rm "${TARFILE}".sha256sum
+echo "Created ${TARFILE/.tgz/-darwin-x64.tgz}"
+
+# Cleanup
+rm -f SHA256SUMS
+rm -rf build
+


### PR DESCRIPTION
Uses streamVideo function of ring-client-api to start a live HLS stream.

This currently doesn't work using the default video viewer in WebThings due to limitations in the HLS library used.

Have opened this PR to get early feedback.